### PR TITLE
Enable doxyqml by default.

### DIFF
--- a/src/DoxygenBuilder/Doxyfile.in
+++ b/src/DoxygenBuilder/Doxyfile.in
@@ -281,7 +281,7 @@ OPTIMIZE_OUTPUT_VHDL   = NO
 # Note that for custom extensions you also need to set FILE_PATTERNS otherwise
 # the files are not read by doxygen.
 
-EXTENSION_MAPPING      =
+EXTENSION_MAPPING      = qml=C++
 
 # If the MARKDOWN_SUPPORT tag is enabled then doxygen pre-processes all comments
 # according to the Markdown format, which allows for more readable
@@ -872,7 +872,7 @@ INPUT_FILTER           =
 # filters are used. If the FILTER_PATTERNS tag is empty or if none of the
 # patterns match the file name, INPUT_FILTER is applied.
 
-FILTER_PATTERNS        =
+FILTER_PATTERNS        = *.qml=doxyqml
 
 # If the FILTER_SOURCE_FILES tag is set to YES, the input filter (if set using
 # INPUT_FILTER) will also be used to filter the input files that are used for


### PR DESCRIPTION
Add the necessary core flags for allowing doxyqml to work. One must
still include *.qml as FILE_PATTERNS flag to add_doxygen in cmake, and
add necessary packaging dependency on doxyqml, but this enables doxygen
to generate docs from qml when those requirements are met.