### PR TITLE
Add #include of <locale.h> to examples/intltool-demo/src/main.cpp

### DIFF
--- a/examples/intltool-demo/src/main.cpp
+++ b/examples/intltool-demo/src/main.cpp
@@ -2,6 +2,7 @@
 #include <gio/gio.h>
 #include <glib.h>
 #include <libintl.h>
+#include <locale.h>
 
 using namespace std;
 


### PR DESCRIPTION
I was seeing compilation failures on Ubuntu, not sure what changed but the fix is simple!